### PR TITLE
feat: improve version-based sorting

### DIFF
--- a/internal/protoversion/compare.go
+++ b/internal/protoversion/compare.go
@@ -1,0 +1,22 @@
+package protoversion
+
+// Compare returns an integer comparing two versions.
+// The result will be 0 if a == b, -1 if a < b, and +1 if a > b.
+func Compare(a, b Version) int {
+	switch {
+	case a.Major < b.Major:
+		return -1
+	case a.Major > b.Major:
+		return 1
+	case a.Stability > b.Stability:
+		return -1
+	case a.Stability < b.Stability:
+		return 1
+	case a.Minor < b.Minor:
+		return -1
+	case a.Minor > b.Minor:
+		return 1
+	default:
+		return 0
+	}
+}

--- a/internal/protoversion/compare_test.go
+++ b/internal/protoversion/compare_test.go
@@ -1,0 +1,69 @@
+package protoversion
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestCompare(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		a, b     Version
+		expected int
+	}{
+		{
+			name:     "identical",
+			a:        Version{Major: 2, Stability: Beta, Minor: 2},
+			b:        Version{Major: 2, Stability: Beta, Minor: 2},
+			expected: 0,
+		},
+
+		{
+			name:     "lower minor",
+			a:        Version{Major: 2, Stability: Beta, Minor: 1},
+			b:        Version{Major: 2, Stability: Beta, Minor: 2},
+			expected: -1,
+		},
+
+		{
+			name:     "higher minor",
+			a:        Version{Major: 2, Stability: Beta, Minor: 2},
+			b:        Version{Major: 2, Stability: Beta, Minor: 1},
+			expected: 1,
+		},
+
+		{
+			name:     "lower stability",
+			a:        Version{Major: 2, Stability: Alpha, Minor: 2},
+			b:        Version{Major: 2, Stability: Beta, Minor: 2},
+			expected: -1,
+		},
+
+		{
+			name:     "higher stability",
+			a:        Version{Major: 2, Stability: Beta, Minor: 2},
+			b:        Version{Major: 2, Stability: Alpha, Minor: 2},
+			expected: 1,
+		},
+
+		{
+			name:     "lower minor higher stability",
+			a:        Version{Major: 2, Stability: Beta, Minor: 1},
+			b:        Version{Major: 2, Stability: Alpha, Minor: 2},
+			expected: 1,
+		},
+
+		{
+			name:     "stable vs alpha",
+			a:        Version{Major: 1},
+			b:        Version{Major: 1, Stability: Beta, Minor: 1},
+			expected: 1,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := Compare(tt.a, tt.b)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/internal/protoversion/stabilitylevel.go
+++ b/internal/protoversion/stabilitylevel.go
@@ -1,0 +1,16 @@
+package protoversion
+
+// StabilityLevel represents an AIP stability level.
+// See: https://google.aip.dev/181
+type StabilityLevel int
+
+const (
+	// A Stable component must be fully-supported over the lifetime of the major API version.
+	Stable StabilityLevel = iota
+
+	// A Beta component must be considered complete and ready to be declared stable, subject to public testing.
+	Beta
+
+	// An Alpha component undergoes rapid iteration with a known set of users who must be tolerant of change.
+	Alpha
+)

--- a/internal/protoversion/version.go
+++ b/internal/protoversion/version.go
@@ -1,0 +1,59 @@
+package protoversion
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Version represents a protobuf package version.
+type Version struct {
+	// Major version of the package.
+	Major int
+	// Stability of the package.
+	Stability StabilityLevel
+	// Minor version of the package.
+	Minor int
+}
+
+// Parse a version string.
+func Parse(s string) (Version, error) {
+	if !strings.HasPrefix(s, "v") {
+		return Version{}, fmt.Errorf("missing prefix 'v'")
+	}
+	withoutV := strings.TrimPrefix(s, "v")
+	if strings.HasPrefix(withoutV, "0") {
+		return Version{}, fmt.Errorf("version must not start with 0")
+	}
+	withoutMajor := strings.TrimLeft(withoutV, "0123456789")
+	majorStr := withoutV[:len(withoutV)-len(withoutMajor)]
+	major, err := strconv.Atoi(majorStr)
+	if err != nil {
+		return Version{}, fmt.Errorf("invalid major version: %w", err)
+	}
+	if len(withoutMajor) == 0 {
+		return Version{Major: major}, nil
+	}
+	var withoutStabilityLevel string
+	stabilityLevel := Stable
+	switch {
+	case strings.HasPrefix(withoutMajor, "alpha"):
+		stabilityLevel = Alpha
+		withoutStabilityLevel = strings.TrimPrefix(withoutMajor, "alpha")
+	case strings.HasPrefix(withoutMajor, "beta"):
+		stabilityLevel = Beta
+		withoutStabilityLevel = strings.TrimPrefix(withoutMajor, "beta")
+	}
+	if len(withoutStabilityLevel) == 0 {
+		return Version{Major: major, Stability: stabilityLevel}, nil
+	}
+	minor, err := strconv.Atoi(withoutStabilityLevel)
+	if err != nil {
+		return Version{}, fmt.Errorf("invalid minor version: %w", err)
+	}
+	return Version{
+		Major:     major,
+		Stability: stabilityLevel,
+		Minor:     minor,
+	}, nil
+}

--- a/internal/protoversion/version_test.go
+++ b/internal/protoversion/version_test.go
@@ -1,0 +1,54 @@
+package protoversion
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestParse(t *testing.T) {
+	for _, tt := range []struct {
+		version       string
+		expected      Version
+		errorContains string
+	}{
+		{
+			version:  "v1",
+			expected: Version{Major: 1},
+		},
+
+		{
+			version:  "v2",
+			expected: Version{Major: 2, Stability: Stable},
+		},
+
+		{
+			version:  "v1beta1",
+			expected: Version{Major: 1, Stability: Beta, Minor: 1},
+		},
+
+		{
+			version:  "v1beta2",
+			expected: Version{Major: 1, Stability: Beta, Minor: 2},
+		},
+
+		{
+			version:  "v2alpha3",
+			expected: Version{Major: 2, Stability: Alpha, Minor: 3},
+		},
+
+		{
+			version:       "foo",
+			errorContains: "missing prefix 'v'",
+		},
+	} {
+		t.Run(tt.version, func(t *testing.T) {
+			actual, err := Parse(tt.version)
+			if tt.errorContains != "" {
+				assert.ErrorContains(t, err, tt.errorContains)
+			} else {
+				assert.Equal(t, tt.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Ensures that CLI use suffixes are more consistently appended to lower
versions (e.g. v1beta1 gets a suffix instead of v1).
