### PR TITLE
feat: set default output to stdout

### DIFF
--- a/aipcli/config.go
+++ b/aipcli/config.go
@@ -2,6 +2,7 @@ package aipcli
 
 import (
 	"context"
+	"os"
 
 	"github.com/spf13/cobra"
 	"google.golang.org/genproto/googleapis/api/annotations"
@@ -43,6 +44,7 @@ func initContext(cmd *cobra.Command, config Config) {
 	cmd.SetContext(context.WithValue(ctx, contextKey{}, &contextValue{
 		config: config,
 	}))
+	cmd.SetOut(os.Stdout)
 }
 
 func initPersistentFlags(cmd *cobra.Command) {


### PR DESCRIPTION
For some reason, command output was written to stderr.

This commit unexpectedly also changes usage output printed to stdout instead of stderr.