### PR TITLE
feat: present zero values by default

### DIFF
--- a/aipcli/invoke.go
+++ b/aipcli/invoke.go
@@ -31,7 +31,8 @@ func invoke(cmd *cobra.Command, uri string, request, response proto.Message) err
 
 func format(msg proto.Message) string {
 	return protojson.MarshalOptions{
-		Multiline: true,
-		Indent:    "  ",
+		Multiline:       true,
+		Indent:          "  ",
+		EmitUnpopulated: true,
 	}.Format(msg)
 }


### PR DESCRIPTION
Today zero values are not presented, which can be
confusing when you are not aware of the data model.

With this the whole data model will be presented.
