### PR TITLE
feat: add support for repeated enum fields

### DIFF
--- a/aipcli/flags.go
+++ b/aipcli/flags.go
@@ -79,7 +79,7 @@ func setFlags(
 			}
 		case protoreflect.EnumKind:
 			if field.IsList() {
-				// TODO: Implement support for repeated enums.
+				addFlag(cmd, field, parentFields, comments[field.FullName()], protovalue.EnumList(mutable, field))
 			} else {
 				addFlag(cmd, field, parentFields, comments[field.FullName()], protovalue.Enum(mutable, field))
 			}

--- a/proto/einride/aipcli/v1/values.proto
+++ b/proto/einride/aipcli/v1/values.proto
@@ -27,4 +27,12 @@ message Values {
   map<string, string> map_string_string = 9;
   // Map from string to int64.
   map<string, int64> map_string_int64 = 10;
+
+  enum Enum {
+    ENUM_UNSPECIFIED = 0;
+    ENUM_ONE = 1;
+    ENUM_TWO = 2;
+  }
+  // Repeated enum.
+  repeated Enum repeated_enum = 11;
 }


### PR DESCRIPTION
Feedback welcome on how this should be structured and perhaps tested. I tested locally in one of my proto CLIs where the repeated enum flag is now picked up and accepting comma separated enum values.