### PR TITLE
fix: expose GetConfig of cobra commmand

### DIFF
--- a/aipcli/config.go
+++ b/aipcli/config.go
@@ -111,7 +111,7 @@ func getContext(cmd *cobra.Command) (context.Context, bool) {
 	return nil, false
 }
 
-func getConfig(cmd *cobra.Command) Config {
+func GetConfig(cmd *cobra.Command) Config {
 	ctx, ok := getContext(cmd)
 	if !ok {
 		return Config{}
@@ -126,13 +126,13 @@ func getAddress(cmd *cobra.Command) (string, bool) {
 	if flagAddress, err := cmd.Flags().GetString(addressFlag); err == nil && flagAddress != "" {
 		return flagAddress, true
 	}
-	for host, hostAddress := range getConfig(cmd).Hosts {
+	for host, hostAddress := range GetConfig(cmd).Hosts {
 		if useHost, err := cmd.Flags().GetBool(host); err == nil && useHost {
 			return hostAddress, true
 		}
 	}
-	if defaultHostFromConfig := getConfig(cmd).DefaultHost; defaultHostFromConfig != "" {
-		for host, hostAddress := range getConfig(cmd).Hosts {
+	if defaultHostFromConfig := GetConfig(cmd).DefaultHost; defaultHostFromConfig != "" {
+		for host, hostAddress := range GetConfig(cmd).Hosts {
 			if host == defaultHostFromConfig {
 				return hostAddress, true
 			}
@@ -145,7 +145,7 @@ func getToken(cmd *cobra.Command) (string, bool) {
 	if flagToken, err := cmd.Flags().GetString(tokenFlag); err == nil && flagToken != "" {
 		return flagToken, true
 	}
-	if getConfig(cmd).GoogleCloudIdentityTokens {
+	if GetConfig(cmd).GoogleCloudIdentityTokens {
 		return gcloudAuthPrintIdentityToken()
 	}
 	return "", false
@@ -156,7 +156,7 @@ func isInsecure(cmd *cobra.Command) bool {
 	return result && err == nil
 }
 
-func isVerbose(cmd *cobra.Command) bool {
+func IsVerbose(cmd *cobra.Command) bool {
 	result, err := cmd.Flags().GetBool(verboseFlag)
 	return result && err == nil
 }

--- a/aipcli/dial.go
+++ b/aipcli/dial.go
@@ -24,7 +24,7 @@ func dial(cmd *cobra.Command) (*grpc.ClientConn, error) {
 	if !ok {
 		return nil, fmt.Errorf("dial: no address")
 	}
-	if isVerbose(cmd) {
+	if IsVerbose(cmd) {
 		cmd.PrintErrln(">> address:", address)
 	}
 	var opts []grpc.DialOption
@@ -58,7 +58,7 @@ func dialInsecure(cmd *cobra.Command) (*grpc.ClientConn, error) {
 	case hasToken && !strings.HasPrefix(address, "localhost:"):
 		return nil, fmt.Errorf("must connect to localhost with --insecure and --token")
 	}
-	if isVerbose(cmd) {
+	if IsVerbose(cmd) {
 		cmd.PrintErrln(">> insecure address:", address)
 	}
 	opts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}

--- a/aipcli/help.go
+++ b/aipcli/help.go
@@ -141,7 +141,7 @@ func isConnectionFlag(cmd *cobra.Command, flag *pflag.Flag) bool {
 }
 
 func isHostFlag(cmd *cobra.Command, flag *pflag.Flag) bool {
-	for host := range getConfig(cmd).Hosts {
+	for host := range GetConfig(cmd).Hosts {
 		if flag.Name == host {
 			return true
 		}

--- a/aipcli/invoke.go
+++ b/aipcli/invoke.go
@@ -14,7 +14,7 @@ func invoke(cmd *cobra.Command, uri string, request, response proto.Message) err
 	if err != nil {
 		return err
 	}
-	if isVerbose(cmd) {
+	if IsVerbose(cmd) {
 		for _, line := range strings.Split(format(request), "\n") {
 			cmd.PrintErrln(">>", line)
 		}


### PR DESCRIPTION
For extend we would like to have a custom way of handling the setting of a host on the commands. For this it would help if the Config of the command is exposed. 

In addition I also exposed the setting of 'IsVerbose', to be able to add helpful debug logging. 