### PR TITLE
feat: allow positional name argument for get methods

### DIFF
--- a/internal/protoflag/primitive.go
+++ b/internal/protoflag/primitive.go
@@ -27,7 +27,7 @@ type primitiveValue[T any] struct {
 }
 
 func (v primitiveValue[T]) String() string {
-	return ""
+	return v.mutable().Get(v.field).String()
 }
 
 func (v primitiveValue[T]) Set(s string) error {


### PR DESCRIPTION
Makes it possible to do Get without specifying the `--name` flag, e.g. these ones are equal:
* `examplectl freight get-site --name resource`
* `examplectl freight get-site resource`

Specifying both positional and `--name` arguments is not allowed.

I feel it could be quite useful, but perhaps could be confusing that some operations behaves differently 🤔 