### PR TITLE
feat: simplify saga auth token config

### DIFF
--- a/aipcli/token.go
+++ b/aipcli/token.go
@@ -27,11 +27,11 @@ type IdentityTokenFile struct {
 }
 
 func identityTokenFromConfigFile(tokenFile string) (string, error) {
-	configDir, err := os.UserConfigDir()
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
 	}
-	configFile := path.Join(configDir, tokenFile)
+	configFile := path.Join(homeDir, ".config", "saga", tokenFile)
 	file, err := ioutil.ReadFile(configFile)
 	if err != nil {
 		return "", err

--- a/cmd/examplectl/gen/root.go
+++ b/cmd/examplectl/gen/root.go
@@ -23,5 +23,5 @@ func NewModuleCommand(use string, short string, commands ...*cobra.Command) *cob
 }
 
 func NewConfig() aipcli.Config {
-	return aipcli.Config{Hosts: map[string]string{}, DefaultHost: "", Root: "examplectl", GoogleCloudIdentityTokens: true, CachedIdentityTokenPath: ""}
+	return aipcli.Config{Hosts: map[string]string{}, DefaultHost: "", Root: "examplectl", GoogleCloudIdentityTokens: true}
 }

--- a/internal/gengoaipcli/config.go
+++ b/internal/gengoaipcli/config.go
@@ -18,12 +18,6 @@ func (c *Config) AddToFlagSet(flags *pflag.FlagSet) {
 	flags.StringVar(&c.DefaultHost, "default_host", "", "default host override")
 	flags.StringVar(&c.Root, "root", "", "root command")
 	flags.BoolVar(&c.GoogleCloudIdentityTokens, "gcloud_identity_tokens", false, "use gcloud to print identity tokens")
-	flags.StringVar(
-		&c.CachedIdentityTokenPath,
-		"cached_identity_token_path",
-		"",
-		"a file relative to the local config folder that provides an IdentityToken used by the CLI",
-	)
 }
 
 // Validate the config.
@@ -35,11 +29,6 @@ func (c *Config) Validate() error {
 		}
 		return fmt.Errorf("default_host (%s) must be one of hosts (%s)", c.DefaultHost, strings.Join(hosts, ","))
 	}
-
-	if c.GoogleCloudIdentityTokens && c.CachedIdentityTokenPath != "" {
-		return fmt.Errorf("gcloud_identity_tokens and cached_identity_token_path are mutually exclusive flags")
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
Just showing a potential way to split the saga dev/prod token storage and simplify the config a bit. This should allow use to do saga login once for dev or prod then don't need to login anymore. Otherwise each time they switch a call between the two environments, they need to login again.

Changes include:
* Remove `CachedIdentityTokenPath` config, but use a fixed token storage path as `~/.config/saga/token.<env>.json`
* Check host key whether starting with `dev-` or not to decide which token json file to use.

This should work when used with https://github.com/einride/saga-auth-cli-go/pull/4