### PR TITLE
feat: introduce root path

### DIFF
--- a/aipcli/config.go
+++ b/aipcli/config.go
@@ -16,6 +16,8 @@ type Config struct {
 	Hosts map[string]string
 	// DefaultHost is the host ID of the default host.
 	DefaultHost string
+	// RootPath is where the root file will be located.
+	RootPath string
 	// Root is the name of the root module package.
 	Root string
 	// GoogleCloudIdentityTokens indicates if Google Cloud Identity Tokens should be automatically generated.

--- a/cmd/examplectl/gen/root.go
+++ b/cmd/examplectl/gen/root.go
@@ -23,5 +23,5 @@ func NewModuleCommand(use string, short string, commands ...*cobra.Command) *cob
 }
 
 func NewConfig() aipcli.Config {
-	return aipcli.Config{Hosts: map[string]string{}, DefaultHost: "", Root: "examplectl", GoogleCloudIdentityTokens: true, CachedIdentityTokenPath: ""}
+	return aipcli.Config{Hosts: map[string]string{}, DefaultHost: "", RootPath: "", Root: "examplectl", GoogleCloudIdentityTokens: true, CachedIdentityTokenPath: ""}
 }

--- a/internal/gengoaipcli/config.go
+++ b/internal/gengoaipcli/config.go
@@ -17,6 +17,7 @@ func (c *Config) AddToFlagSet(flags *pflag.FlagSet) {
 	flags.Var(stringStringMap{value: c.Hosts}, "hosts", "mapping from alias to host")
 	flags.StringVar(&c.DefaultHost, "default_host", "", "default host override")
 	flags.StringVar(&c.Root, "root", "", "root command")
+	flags.StringVar(&c.RootPath, "root_path", "", "where root will be located")
 	flags.BoolVar(&c.GoogleCloudIdentityTokens, "gcloud_identity_tokens", false, "use gcloud to print identity tokens")
 	flags.StringVar(
 		&c.CachedIdentityTokenPath,

--- a/internal/gengoaipcli/run.go
+++ b/internal/gengoaipcli/run.go
@@ -42,7 +42,7 @@ func generateRootModuleFile(gen *protogen.Plugin, config Config) error {
 	if !ok {
 		return fmt.Errorf("param root requires param module to be provided")
 	}
-	g := gen.NewGeneratedFile(path.Join(module, "root.go"), "")
+	g := gen.NewGeneratedFile(path.Join(module, config.RootPath, "root.go"), "")
 	generateGeneratedFileHeader(g)
 	g.P("package ", config.Root)
 	cobraCommand := g.QualifiedGoIdent(protogen.GoIdent{


### PR DESCRIPTION
It allows the root.go to be placed in a different directory. Usefull when we want to generate multiple CLIs.
