### PR TITLE
feat: remove insecure token checks

### DIFF
--- a/aipcli/dial.go
+++ b/aipcli/dial.go
@@ -89,13 +89,10 @@ func dial(cmd *cobra.Command) (*grpc.ClientConn, error) {
 }
 
 func dialInsecure(cmd *cobra.Command) (*grpc.ClientConn, error) {
-	token, hasToken := getToken(cmd)
+	token, _ := getToken(cmd)
 	address, hasAddress := getAddress(cmd)
-	switch {
-	case !hasAddress:
+	if !hasAddress {
 		return nil, fmt.Errorf("must provide --address with --insecure")
-	case hasToken && !strings.HasPrefix(address, "localhost:"):
-		return nil, fmt.Errorf("must connect to localhost with --insecure and --token")
 	}
 	if IsVerbose(cmd) {
 		cmd.PrintErrln(">> insecure address:", address)


### PR DESCRIPTION
When a user specifies --insecure (most often to run locally), he should
be able to use the token that may be already locally stored (with the
recent introduction of local tokens) so we should not force the use to
write something like

`myctl cmd --insecure --token $(myctl auth print-identity-token)`

when the cli is already able to automatically supply the `--token` flag.
