### PR TITLE
feat(deps): bump go.einride.tech/sage from 0.278.0 to 0.279.1 in /.sage

### DIFF
--- a/.sage/go.mod
+++ b/.sage/go.mod
@@ -2,4 +2,4 @@ module sage
 
 go 1.22.1
 
-require go.einride.tech/sage v0.278.0
+require go.einride.tech/sage v0.279.1

--- a/.sage/go.sum
+++ b/.sage/go.sum
@@ -1,2 +1,2 @@
-go.einride.tech/sage v0.278.0 h1:I3J2eM/5dIo6YYuozGE2hTNEjJpIaM/jESOY7tlfwZo=
-go.einride.tech/sage v0.278.0/go.mod h1:EzV5uciFX7/2ho8EKB5K9JghOfXIxlzs694b+Tkl5GQ=
+go.einride.tech/sage v0.279.1 h1:Xq8I4eYG1aqpU8L+kasIX129q0UEyWkH+iyagi7gQgM=
+go.einride.tech/sage v0.279.1/go.mod h1:EzV5uciFX7/2ho8EKB5K9JghOfXIxlzs694b+Tkl5GQ=

--- a/aipcli/token.go
+++ b/aipcli/token.go
@@ -2,7 +2,6 @@ package aipcli
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -32,7 +31,7 @@ func identityTokenFromConfigFile(tokenFile string) (string, error) {
 		return "", err
 	}
 	configFile := path.Join(configDir, tokenFile)
-	file, err := ioutil.ReadFile(configFile)
+	file, err := os.ReadFile(configFile)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Replaces #224

Bumps [go.einride.tech/sage](https://github.com/einride/sage) from 0.278.0 to 0.279.1.
- [Release notes](https://github.com/einride/sage/releases)
- [Commits](https://github.com/einride/sage/compare/v0.278.0...v0.279.1)

---
updated-dependencies:
- dependency-name: go.einride.tech/sage
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>
