### PR TITLE
feat: add support for passing options + global token function

### DIFF
--- a/aipcli/config.go
+++ b/aipcli/config.go
@@ -149,24 +149,21 @@ func getAddress(cmd *cobra.Command) (string, bool) {
 	return defaultHostFromProto(cmd)
 }
 
-func getToken(cmd *cobra.Command) (string, bool) {
+func getToken(cmd *cobra.Command) (string, error) {
 	if flagToken, err := cmd.Flags().GetString(tokenFlag); err == nil && flagToken != "" {
-		return flagToken, true
+		return flagToken, nil
 	}
 
-	if GetConfig(cmd).CachedIdentityTokenPath != "" {
-		tokenFile := GetConfig(cmd).CachedIdentityTokenPath
-		identityToken, err := identityTokenFromConfigFile(tokenFile)
-		if err != nil {
-			return "", false
-		}
-		return identityToken, true
+	tokenFunc := getGlobalTokenFunc(cmd)
+	if tokenFunc != nil {
+		return tokenFunc(cmd)
 	}
 
-	if GetConfig(cmd).GoogleCloudIdentityTokens {
-		return gcloudAuthPrintIdentityToken()
+	token, err := defaultTokenFunc(cmd)
+	if err != nil {
+		return "", err
 	}
-	return "", false
+	return token, nil
 }
 
 func isInsecure(cmd *cobra.Command) bool {

--- a/aipcli/dial.go
+++ b/aipcli/dial.go
@@ -32,7 +32,11 @@ func dial(cmd *cobra.Command) (*grpc.ClientConn, error) {
 		cmd.PrintErrln(">> address:", address)
 	}
 	var opts []grpc.DialOption
-	if token, ok := getToken(cmd); ok {
+	token, err := getToken(cmd)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get bearer token: %v", err)
+	}
+	if token != "" {
 		opts = append(
 			opts,
 			grpc.WithPerRPCCredentials(

--- a/aipcli/options.go
+++ b/aipcli/options.go
@@ -1,0 +1,123 @@
+package aipcli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+type OptFunc func(*Options)
+
+type globalTokenFunc func(cmd *cobra.Command) (string, error)
+
+type Options struct {
+	tokenFunc globalTokenFunc
+}
+
+type optionsContextKey struct{}
+
+type optionsContextValue struct {
+	options Options
+}
+
+// WithGlobalTokenFunc allows defining how a bearer token is obtained for all commands which
+// perform gRPC calls to the target service.
+// If WithGlobalTokenFunc is defined on more than 1 command in the command hierarchy, the highest
+// one in the hierarchy will be the one used.
+// If no token function is defined, the default token function will be used.
+func WithGlobalTokenFunc(tokenFunc func(cmd *cobra.Command) (string, error)) OptFunc {
+	return func(o *Options) {
+		o.tokenFunc = tokenFunc
+	}
+}
+
+// getOptionFromChildren walks through the entire tree of commands starting with the given cmd,
+// looking for an option of type T in each command's context. If it finds one, it calls the
+// given update function, allowing it to decide what to return and eventually returning the final value.
+func getOptionFromChildren(cmd *cobra.Command, updateFunc func(currentVal any, allOpts Options) any) any {
+	var val any
+	var update func(c *cobra.Command)
+	update = func(cmd *cobra.Command) {
+		ctx := cmd.Context()
+		// If we have a context, with an optionsContextValue, update the value with the update function.
+		if ctx != nil {
+			if v := ctx.Value(optionsContextKey{}); v != nil {
+				if typedVal, ok := v.(*optionsContextValue); ok {
+					val = updateFunc(val, typedVal.options)
+				}
+			}
+		}
+		for _, child := range cmd.Commands() {
+			update(child)
+		}
+	}
+	update(cmd)
+
+	return val
+}
+
+// setCommandOptions sets the Options in the given command's context.
+func setCommandOptions(cmd *cobra.Command, options Options) {
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cmd.SetContext(context.WithValue(ctx, optionsContextKey{}, &optionsContextValue{
+		options: options,
+	}))
+}
+
+func defaultTokenFunc(cmd *cobra.Command) (string, error) {
+	if GetConfig(cmd).CachedIdentityTokenPath != "" {
+		tokenFile := GetConfig(cmd).CachedIdentityTokenPath
+		identityToken, err := identityTokenFromConfigFile(tokenFile)
+		if err != nil {
+			return "", fmt.Errorf("failed to read identity token from config file: %v", err)
+		}
+		return identityToken, nil
+	}
+
+	if GetConfig(cmd).GoogleCloudIdentityTokens {
+		identityToken, ok := gcloudAuthPrintIdentityToken()
+		if !ok {
+			return "", fmt.Errorf("failed to print identity token")
+		}
+		return identityToken, nil
+	}
+
+	return "", nil
+}
+
+// getGlobalTokenFunc walks down the command hierarchy from the root cmd,
+// looking for a global token function in each command's context. If it finds one, it returns it.
+// If it doesn't find one, it returns nil.
+// Validation is performed to ensure that only one global token function has set.
+func getGlobalTokenFunc(cmd *cobra.Command) globalTokenFunc {
+	updateFunc := func(currentVal any, opts Options) any {
+		if currentVal != nil {
+			cmd.PrintErrf(
+				//nolint:lll
+				`WARNING: command %s attempted to configure a global token function (WithGlobalTokenFunc) when another command has already done so. This is currently not supported and will be ignored.`,
+				cmd.Name(),
+			)
+			return currentVal
+		}
+		if opts.tokenFunc == nil {
+			return nil
+		}
+		return &opts.tokenFunc
+	}
+	val := getOptionFromChildren(
+		cmd.Root(),
+		updateFunc,
+	)
+	if val == nil {
+		return nil
+	}
+	f, ok := val.(*globalTokenFunc)
+	if !ok {
+		return nil
+	}
+	return *f
+}

--- a/aipcli/options_test.go
+++ b/aipcli/options_test.go
@@ -1,0 +1,425 @@
+package aipcli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"gotest.tools/v3/assert"
+)
+
+func TestDefaultTokenFunc_behavior(t *testing.T) {
+	t.Run("returns error with missing file if CachedIdentityTokenPath set", func(t *testing.T) {
+		// Given
+		cmd := &cobra.Command{}
+		initContext(cmd, Config{CachedIdentityTokenPath: "not_a_file.json"})
+		// When
+		token, err := defaultTokenFunc(cmd)
+		// Then
+		assert.ErrorContains(t, err, "failed to read identity token from config file")
+		assert.Equal(t, token, "")
+	})
+
+	t.Run("returns empty string if config blank", func(t *testing.T) {
+		// Given
+		cmd := &cobra.Command{}
+		initContext(cmd, Config{})
+		// When
+		token, err := defaultTokenFunc(cmd)
+		// Then
+		assert.NilError(t, err)
+		assert.Equal(t, token, "")
+	})
+
+	t.Run("returns empty string if config not initialized", func(t *testing.T) {
+		// Given
+		cmd := &cobra.Command{}
+		// When
+		token, err := defaultTokenFunc(cmd)
+		// Then
+		assert.NilError(t, err)
+		assert.Equal(t, token, "")
+	})
+}
+
+func TestSetCommandOptions(t *testing.T) {
+	t.Run("sets options when context exists", func(t *testing.T) {
+		// Given
+		cmd := &cobra.Command{}
+		cmd.SetContext(context.WithValue(context.Background(), contextKey{}, &contextValue{}))
+		opts := Options{
+			tokenFunc: func(_ *cobra.Command) (string, error) {
+				return "test-token", nil
+			},
+		}
+		// When
+		setCommandOptions(cmd, opts)
+
+		// Then
+		ctx := cmd.Context()
+		assert.Assert(t, ctx != nil)
+		ctxVal := ctx.Value(optionsContextKey{})
+		assert.Assert(t, ctxVal != nil)
+		typedVal, ok := ctxVal.(*optionsContextValue)
+		assert.Assert(t, ok)
+		assert.Assert(t, typedVal.options.tokenFunc != nil)
+		token, err := typedVal.options.tokenFunc(cmd)
+		assert.NilError(t, err)
+		assert.Equal(t, token, "test-token")
+	})
+
+	t.Run("sets options when context is nil", func(t *testing.T) {
+		// Given
+		cmd := &cobra.Command{}
+		opts := Options{
+			tokenFunc: func(_ *cobra.Command) (string, error) {
+				return "test-token-2", nil
+			},
+		}
+		// When
+		setCommandOptions(cmd, opts)
+
+		// Then
+		ctx := cmd.Context()
+		assert.Assert(t, ctx != nil)
+		ctxVal := ctx.Value(optionsContextKey{})
+		assert.Assert(t, ctxVal != nil)
+		typedVal, ok := ctxVal.(*optionsContextValue)
+		assert.Assert(t, ok)
+		assert.Assert(t, typedVal.options.tokenFunc != nil)
+		token, err := typedVal.options.tokenFunc(cmd)
+		assert.NilError(t, err)
+		assert.Equal(t, token, "test-token-2")
+	})
+
+	t.Run("sets options with nil tokenFunc", func(t *testing.T) {
+		// Given
+		cmd := &cobra.Command{}
+		opts := Options{
+			tokenFunc: nil,
+		}
+		// When
+		setCommandOptions(cmd, opts)
+
+		// Then
+		ctx := cmd.Context()
+		assert.Assert(t, ctx != nil)
+		ctxVal := ctx.Value(optionsContextKey{})
+		assert.Assert(t, ctxVal != nil)
+		typedVal, ok := ctxVal.(*optionsContextValue)
+		assert.Assert(t, ok)
+		assert.Assert(t, typedVal.options.tokenFunc == nil)
+	})
+}
+
+func TestGetOptionFromChildren(t *testing.T) {
+	t.Run("returns nil when no options found", func(t *testing.T) {
+		// Given
+		cmd := &cobra.Command{}
+		// When
+		result := getOptionFromChildren(cmd, func(currentVal any, _ Options) any {
+			return currentVal
+		})
+		// Then
+		assert.Assert(t, result == nil)
+	})
+
+	t.Run("finds options in root command", func(t *testing.T) {
+		// Given
+		root := &cobra.Command{Use: "root"}
+		opts := Options{
+			tokenFunc: func(_ *cobra.Command) (string, error) {
+				return "root-token", nil
+			},
+		}
+		setCommandOptions(root, opts)
+
+		var foundTokenFunc *globalTokenFunc
+		// When
+		result := getOptionFromChildren(root, func(_ any, allOpts Options) any {
+			if allOpts.tokenFunc != nil {
+				foundTokenFunc = &allOpts.tokenFunc
+			}
+			return foundTokenFunc
+		})
+		// Then
+		assert.Assert(t, result != nil)
+		tokenFunc, ok := result.(*globalTokenFunc)
+		assert.Assert(t, ok)
+		token, err := (*tokenFunc)(root)
+		assert.NilError(t, err)
+		assert.Equal(t, token, "root-token")
+	})
+
+	t.Run("finds options in child command", func(t *testing.T) {
+		// Given
+		root := &cobra.Command{Use: "root"}
+		child := &cobra.Command{Use: "child"}
+		root.AddCommand(child)
+
+		opts := Options{
+			tokenFunc: func(_ *cobra.Command) (string, error) {
+				return "child-token", nil
+			},
+		}
+		setCommandOptions(child, opts)
+
+		// When
+		var foundTokenFunc *globalTokenFunc
+		result := getOptionFromChildren(root, func(_ any, allOpts Options) any {
+			if allOpts.tokenFunc != nil {
+				foundTokenFunc = &allOpts.tokenFunc
+			}
+			return foundTokenFunc
+		})
+		// Then
+		assert.Assert(t, result != nil)
+		tokenFunc, ok := result.(*globalTokenFunc)
+		assert.Assert(t, ok)
+		token, err := (*tokenFunc)(child)
+		assert.NilError(t, err)
+		assert.Equal(t, token, "child-token")
+	})
+
+	t.Run("finds options in nested child commands", func(t *testing.T) {
+		// Given
+		root := &cobra.Command{Use: "root"}
+		child1 := &cobra.Command{Use: "child1"}
+		child2 := &cobra.Command{Use: "child2"}
+		root.AddCommand(child1)
+		child1.AddCommand(child2)
+
+		opts := Options{
+			tokenFunc: func(_ *cobra.Command) (string, error) {
+				return "child2-token", nil
+			},
+		}
+		setCommandOptions(child2, opts)
+
+		// When
+		var foundTokenFunc *globalTokenFunc
+		result := getOptionFromChildren(root, func(_ any, allOpts Options) any {
+			if allOpts.tokenFunc != nil {
+				foundTokenFunc = &allOpts.tokenFunc
+			}
+			return foundTokenFunc
+		})
+		assert.Assert(t, result != nil)
+		tokenFunc, ok := result.(*globalTokenFunc)
+		assert.Assert(t, ok)
+		token, err := (*tokenFunc)(child2)
+		assert.NilError(t, err)
+		assert.Equal(t, token, "child2-token")
+	})
+
+	t.Run("update function can accumulate values", func(t *testing.T) {
+		// Given
+		root := &cobra.Command{Use: "root"}
+		child1 := &cobra.Command{Use: "child1"}
+		child2 := &cobra.Command{Use: "child2"}
+		root.AddCommand(child1)
+		root.AddCommand(child2)
+
+		opts1 := Options{
+			tokenFunc: func(_ *cobra.Command) (string, error) {
+				return "token1", nil
+			},
+		}
+		opts2 := Options{
+			tokenFunc: func(_ *cobra.Command) (string, error) {
+				return "token2", nil
+			},
+		}
+
+		setCommandOptions(child1, opts1)
+		setCommandOptions(child2, opts2)
+
+		// When
+		var count int
+		result := getOptionFromChildren(root, func(_ any, allOpts Options) any {
+			if allOpts.tokenFunc != nil {
+				count++
+			}
+			return &count
+		})
+
+		// Then
+		assert.Assert(t, result != nil)
+		countPtr, ok := result.(*int)
+		assert.Assert(t, ok)
+		assert.Equal(t, *countPtr, 2)
+	})
+
+	t.Run("handles commands with nil context", func(t *testing.T) {
+		// Given
+		root := &cobra.Command{Use: "root"}
+		child := &cobra.Command{Use: "child"}
+		root.AddCommand(child)
+		// child has nil context
+
+		// When
+		result := getOptionFromChildren(root, func(currentVal any, _ Options) any {
+			return currentVal
+		})
+		// Then
+		assert.Assert(t, result == nil)
+	})
+
+	t.Run("handles context without options", func(t *testing.T) {
+		// Given
+		root := &cobra.Command{Use: "root"}
+		root.SetContext(context.WithValue(context.Background(), contextKey{}, &contextValue{}))
+
+		// When
+		result := getOptionFromChildren(root, func(currentVal any, _ Options) any {
+			return currentVal
+		})
+
+		// Then
+		assert.Assert(t, result == nil)
+	})
+}
+
+func TestGetGlobalTokenFunc(t *testing.T) {
+	t.Run("returns nil when no token func is set", func(t *testing.T) {
+		// Given
+		root := &cobra.Command{Use: "root"}
+		result := getGlobalTokenFunc(root)
+		// Then
+		assert.Assert(t, result == nil)
+	})
+
+	t.Run("returns token func when set on root", func(t *testing.T) {
+		// Given
+		root := &cobra.Command{Use: "root"}
+		opts := Options{
+			tokenFunc: func(_ *cobra.Command) (string, error) {
+				return "root-token", nil
+			},
+		}
+		setCommandOptions(root, opts)
+
+		// When
+		tokenFunc := getGlobalTokenFunc(root)
+
+		// Then
+		assert.Assert(t, tokenFunc != nil)
+		token, err := tokenFunc(root)
+		assert.NilError(t, err)
+		assert.Equal(t, token, "root-token")
+	})
+
+	t.Run("returns token func when set on child", func(t *testing.T) {
+		// Given
+		root := &cobra.Command{Use: "root"}
+		child := &cobra.Command{Use: "child"}
+		root.AddCommand(child)
+
+		opts := Options{
+			tokenFunc: func(_ *cobra.Command) (string, error) {
+				return "child-token", nil
+			},
+		}
+		setCommandOptions(child, opts)
+
+		// When
+		tokenFunc := getGlobalTokenFunc(child)
+
+		// Then
+		assert.Assert(t, tokenFunc != nil)
+		token, err := tokenFunc(child)
+		assert.NilError(t, err)
+		assert.Equal(t, token, "child-token")
+	})
+
+	t.Run("returns nil when token func is nil in options", func(t *testing.T) {
+		// Given
+		root := &cobra.Command{Use: "root"}
+		opts := Options{
+			tokenFunc: nil,
+		}
+		setCommandOptions(root, opts)
+
+		// When
+		result := getGlobalTokenFunc(root)
+
+		// Then
+		assert.Assert(t, result == nil)
+	})
+
+	t.Run("warns and returns first token func when multiple are set", func(t *testing.T) {
+		// Given
+		root := &cobra.Command{Use: "root"}
+		child1 := &cobra.Command{Use: "child1"}
+		child2 := &cobra.Command{Use: "child2"}
+		root.AddCommand(child1)
+		root.AddCommand(child2)
+
+		opts1 := Options{
+			tokenFunc: func(_ *cobra.Command) (string, error) {
+				return "token1", nil
+			},
+		}
+		opts2 := Options{
+			tokenFunc: func(_ *cobra.Command) (string, error) {
+				return "token2", nil
+			},
+		}
+		setCommandOptions(child1, opts1)
+		setCommandOptions(child2, opts2)
+
+		var output strings.Builder
+		child2.SetErr(&output)
+
+		// When
+		tokemFunc := getGlobalTokenFunc(child2)
+
+		// Then
+		assert.Assert(t, tokemFunc != nil)
+		// Should return the first one found (child1's token func)
+		token, err := tokemFunc(child2)
+		assert.NilError(t, err)
+		assert.Equal(t, token, "token1")
+		// Should print warning
+		assert.Assert(t, strings.Contains(output.String(), "WARNING"))
+		assert.Assert(t, strings.Contains(output.String(), "child2"))
+	})
+
+	t.Run("returns token func from highest in hierarchy when multiple are set", func(t *testing.T) {
+		// Given
+		root := &cobra.Command{Use: "root"}
+		child1 := &cobra.Command{Use: "child1"}
+		child2 := &cobra.Command{Use: "child2"}
+		root.AddCommand(child1)
+		child1.AddCommand(child2)
+
+		opts1 := Options{
+			tokenFunc: func(_ *cobra.Command) (string, error) {
+				return "token1", nil
+			},
+		}
+		opts2 := Options{
+			tokenFunc: func(_ *cobra.Command) (string, error) {
+				return "token2", nil
+			},
+		}
+		setCommandOptions(root, opts1)
+		setCommandOptions(child2, opts2)
+
+		var output strings.Builder
+		child2.SetErr(&output)
+
+		// When
+		tokenFunc := getGlobalTokenFunc(child2)
+
+		// Then
+		assert.Assert(t, tokenFunc != nil)
+		// Should return the first one found (root's token func)
+		token, err := tokenFunc(child2)
+		assert.NilError(t, err)
+		assert.Equal(t, token, "token1")
+		// Should print warning
+		assert.Assert(t, strings.Contains(output.String(), "WARNING"))
+	})
+}

--- a/cmd/examplectl/gen/root.go
+++ b/cmd/examplectl/gen/root.go
@@ -7,9 +7,33 @@ import (
 	v1 "go.einride.tech/aip-cli/cmd/examplectl/gen/einride/example/freight/v1"
 )
 
+// Deprecated: Use NewModule().Command() instead.
 func NewModuleCommand(use string, short string, commands ...*cobra.Command) *cobra.Command {
 	config := NewConfig()
 	return aipcli.NewModuleCommand(
+		use,
+		short,
+		config,
+		append(
+			[]*cobra.Command{
+				v1.NewFreightServiceCommand(config),
+			},
+			commands...,
+		)...,
+	)
+}
+
+type Module struct {
+	options []aipcli.OptFunc
+}
+
+func NewModule(options ...aipcli.OptFunc) *Module {
+	return &Module{options: options}
+}
+
+func (m *Module) Command(use string, short string, commands ...*cobra.Command) *cobra.Command {
+	config := NewConfig()
+	return aipcli.NewModule(m.options...).Command(
 		use,
 		short,
 		config,

--- a/cmd/examplectl/main.go
+++ b/cmd/examplectl/main.go
@@ -9,7 +9,16 @@ import (
 )
 
 func main() {
-	if err := examplectl.NewModuleCommand(
+	// It is also possible to pass options to NewModule(), for example
+	//
+	// examplectl.NewModule(
+	// 	aipcli.WithGlobalTokenFunc(
+	// 		func(cmd *cobra.Command) (string, error) {
+	//			return <my bearer token>, nil
+	// 		},
+	// 	),
+	// )
+	if err := examplectl.NewModule().Command(
 		"examplectl",
 		"Example CLI tool",
 		aipcli.NewIAMModuleCommand("iam", examplectl.NewConfig()),


### PR DESCRIPTION
In order to support overriding how a bearer token is retrieved we add
support for specifying options to module commands with the single option
supported in this PR being a function where the user of this library can
override how a bearer token is retrieved on a global level.

A couple of interesting decisions were taken in this commit which I'll
attempt to document below:

Since a CLI will generally have its entrypoint on a module command, it
made sense to set the options argument on the constructor function for
that and since the existing API `NewModuleCommand` function already has
a variadic argument, in order to avoid a breaking change, we define a
new `Module` struct with a constructor that takes optional arguments and
then define a `Command` method on that which follows the same API as the
previous `NewModuleCommand` function, adjusting the generated code
accordingly.

In order to avoid complex changes, we set the options in the command
context rather than trying to define a shared state struct which would
mean a lot of chnages in the code base. While not the most Go idiomatic
way of doing things it works in this context and seems to be what the
cobra community has done at times to overcome lack of support for such a
setup in Cobra.

Each command can have its own defined options stored in its own context
but we also want be able to set "global" options, meaning options that
can affect all commands. In order to do that we setup some helper
functions allowing walking down the command chain and find an option
that has been set down that hierarchy.

Lastly, we introduce a new module command option `WithGlobalTokenFunc`
which allows overriding how a bearer token is retrieved before gRPC
service are called globally for all commands. If not supplied the
current behaviour is kept.
