### PR TITLE
chore: bump toolchain to go1.25.10

### DIFF
--- a/.sage/go.mod
+++ b/.sage/go.mod
@@ -2,6 +2,6 @@ module sage
 
 go 1.24.10
 
-toolchain go1.25.8
+toolchain go1.25.10
 
 require go.einride.tech/sage v0.383.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module go.einride.tech/aip-cli
 
 go 1.24.10
 
-toolchain go1.25.8
+toolchain go1.25.10
 
 require (
 	cloud.google.com/go/iam v1.2.1


### PR DESCRIPTION
go1.25.8 has CVEs that cause govulncheck to fail. go1.25.10 is the latest 1.25.x patch (released 2026-05-07) and fixes them.